### PR TITLE
Add compatibility to python 3.10

### DIFF
--- a/biblib/bib.py
+++ b/biblib/bib.py
@@ -90,11 +90,16 @@ class Parser:
         defined in earlier files.
         """
 
+        try:
+            from collections.abc import Iterable as collections_Iterable
+        except AttributeError:
+            from collections import Iterable as collections_Iterable  # does not work in python3.10 anymore
+
         recoverer = messages.InputErrorRecoverer()
         if isinstance(str_or_fp_or_iter, str):
             self.__data = str_or_fp_or_iter
             fname = name or '<string>'
-        elif isinstance(str_or_fp_or_iter, collections.Iterable) and \
+        elif isinstance(str_or_fp_or_iter, collections_Iterable) and \
              not hasattr(str_or_fp_or_iter, 'read'):
             for obj in str_or_fp_or_iter:
                 with recoverer:


### PR DESCRIPTION
This makes biblib work with python 3.10.

The Parser.parse() uses collections.abc per default (which is the only way in
python 3.10) and only falls back to the old collections.Iterable if
collections.abc does not exist.